### PR TITLE
Update position structure

### DIFF
--- a/source/jetstream/iterator.go
+++ b/source/jetstream/iterator.go
@@ -253,11 +253,7 @@ func (i *Iterator) getMessagePosition(msg *nats.Msg) (sdk.Position, error) {
 	}
 
 	position := position{
-		Durable:   i.consumerInfo.Name,
-		Stream:    i.consumerInfo.Stream,
-		Subject:   i.subscription.Subject,
-		Timestamp: metadata.Timestamp,
-		OptSeq:    metadata.Sequence.Stream,
+		OptSeq: metadata.Sequence.Stream,
 	}
 
 	sdkPosition, err := position.marshalSDKPosition()

--- a/source/jetstream/position.go
+++ b/source/jetstream/position.go
@@ -17,21 +17,12 @@ package jetstream
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
 	sdk "github.com/conduitio/conduit-connector-sdk"
 )
 
 // position defines a position model for the JetStream iterator.
 type position struct {
-	// Durable is a durable consumer name.
-	Durable string `json:"durable"`
-	// Stream is a name of a stream the consumer reading from.
-	Stream string `json:"stream"`
-	// Subject is a name of a subject the consumer reading from.
-	Subject string `json:"subject"`
-	// Timestamp of a message or the time the message was read by the connector.
-	Timestamp time.Time `json:"timestamp"`
 	// OptSeq is a position of a message in a stream.
 	OptSeq uint64 `json:"opt_seq"`
 }

--- a/source/jetstream/position_test.go
+++ b/source/jetstream/position_test.go
@@ -33,14 +33,11 @@ func Test_position_marshalPosition(t *testing.T) {
 		{
 			name: "success, all fields",
 			fields: position{
-				Durable: "conduit_push_consumer",
-				Stream:  "FOO_STREAM",
-				Subject: "foo_subject",
-				OptSeq:  32,
+				OptSeq: 32,
 			},
 			want: sdk.Position(
 				//nolint:lll // test
-				`{"durable":"conduit_push_consumer","stream":"FOO_STREAM","subject":"foo_subject","timestamp":"0001-01-01T00:00:00Z","opt_seq":32}`,
+				`{"opt_seq":32}`,
 			),
 			wantErr: false,
 		},
@@ -48,7 +45,7 @@ func Test_position_marshalPosition(t *testing.T) {
 			name:   "success, empty",
 			fields: position{},
 			want: sdk.Position(
-				`{"durable":"","stream":"","subject":"","timestamp":"0001-01-01T00:00:00Z","opt_seq":0}`,
+				`{"opt_seq":0}`,
 			),
 			wantErr: false,
 		},
@@ -60,10 +57,7 @@ func Test_position_marshalPosition(t *testing.T) {
 			t.Parallel()
 
 			p := position{
-				Durable: tt.fields.Durable,
-				Stream:  tt.fields.Stream,
-				Subject: tt.fields.Subject,
-				OptSeq:  tt.fields.OptSeq,
+				OptSeq: tt.fields.OptSeq,
 			}
 
 			got, err := p.marshalSDKPosition()
@@ -96,14 +90,11 @@ func Test_parsePosition(t *testing.T) {
 			name: "success, all fields",
 			args: args{
 				sdkPosition: sdk.Position([]byte(
-					`{"durable":"conduit_push_consumer","stream":"FOO_STREAM","subject":"foo_subject","opt_seq":32}`,
+					`{"opt_seq":32}`,
 				)),
 			},
 			want: position{
-				Durable: "conduit_push_consumer",
-				Stream:  "FOO_STREAM",
-				Subject: "foo_subject",
-				OptSeq:  32,
+				OptSeq: 32,
 			},
 			wantErr: false,
 		},
@@ -115,10 +106,7 @@ func Test_parsePosition(t *testing.T) {
 				)),
 			},
 			want: position{
-				Durable: "",
-				Stream:  "",
-				Subject: "",
-				OptSeq:  0,
+				OptSeq: 0,
 			},
 			wantErr: false,
 		},
@@ -128,10 +116,7 @@ func Test_parsePosition(t *testing.T) {
 				sdkPosition: sdk.Position(nil),
 			},
 			want: position{
-				Durable: "",
-				Stream:  "",
-				Subject: "",
-				OptSeq:  0,
+				OptSeq: 0,
 			},
 			wantErr: false,
 		},
@@ -139,7 +124,7 @@ func Test_parsePosition(t *testing.T) {
 			name: "fail, wrong field type",
 			args: args{
 				sdkPosition: sdk.Position([]byte(
-					`{"durable":"conduit_push_consumer","stream":"FOO_STREAM","subject":"foo_subject","opt_seq":"32"}`,
+					`{"opt_seq":"32"}`,
 				)),
 			},
 			want:    position{},

--- a/source/jetstream/position_test.go
+++ b/source/jetstream/position_test.go
@@ -36,7 +36,6 @@ func Test_position_marshalPosition(t *testing.T) {
 				OptSeq: 32,
 			},
 			want: sdk.Position(
-				//nolint:lll // test
 				`{"opt_seq":32}`,
 			),
 			wantErr: false,


### PR DESCRIPTION
### Description

This PR:

- Updates the `jetstream.Position` structure, it removes the redundant `Durable`, `Stream`, `Subject`, and `Timestamp` fields from the position.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-nats-jetstream/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
