### PR TITLE
Unecessary and invalid ConfigKeyDurable value fix

### DIFF
--- a/source/config_test.go
+++ b/source/config_test.go
@@ -263,6 +263,30 @@ func TestParse(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "success, generated durable name",
+			args: args{
+				cfg: map[string]string{
+					config.KeyURLs:    "nats://127.0.0.1:1222,nats://127.0.0.1:1223,nats://127.0.0.1:1224",
+					config.KeySubject: "foo",
+					ConfigKeyDurable:  "",
+				},
+			},
+			want: Config{
+				Config: config.Config{
+					URLs:          []string{"nats://127.0.0.1:1222", "nats://127.0.0.1:1223", "nats://127.0.0.1:1224"},
+					Subject:       "foo",
+					MaxReconnects: config.DefaultMaxReconnects,
+					ReconnectWait: config.DefaultReconnectWait,
+				},
+				DeliverSubject: ".conduit",
+				Durable:        "conduit-",
+				BufferSize:     defaultBufferSize,
+				DeliverPolicy:  nats.DeliverAllPolicy,
+				AckPolicy:      nats.AckExplicitPolicy,
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -284,6 +308,9 @@ func TestParse(t *testing.T) {
 
 			if strings.HasPrefix(got.Durable, defaultDurablePrefix) {
 				tt.want.Durable = got.Durable
+			}
+
+			if strings.HasSuffix(got.DeliverSubject, defaultDeliverSubjectSuffix) {
 				tt.want.DeliverSubject = got.DeliverSubject
 			}
 

--- a/source/source.go
+++ b/source/source.go
@@ -103,7 +103,7 @@ func (s *Source) Parameters() map[string]sdk.Parameter {
 			Description: "A buffer size for consumed messages.",
 		},
 		ConfigKeyDurable: {
-			Default:     "conduit-<uuid>",
+			Default:     "",
 			Required:    false,
 			Description: "A consumer name.",
 		},


### PR DESCRIPTION
### Description

ConfigKeyDurable, if not set, will generate the [durable value](https://github.com/conduitio-labs/conduit-connector-nats-jetstream/blob/ba15298289f9e201a60ce1ddb45e238f4729cdb7/source/config.go#L158) later on.

The `ConfigKeyDurable` default value is also wrong by adding the character `>` - invalid for the configuration value on NATS.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-nats-jetstream/pulls) for the same update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
