### PR TITLE
Change version to `(devel)`

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -19,9 +19,8 @@ import (
 )
 
 // version is set during the build process (i.e. the Makefile).
-// It follows Go's convention for module version, where the version
-// starts with the letter v, followed by a semantic version.
-var version = "v0.4.0"
+// Default version matches default from runtime/debug.
+var version = "(devel)"
 
 // Specification returns the Plugin's Specification.
 func Specification() sdk.Specification {

--- a/spec.go
+++ b/spec.go
@@ -21,7 +21,7 @@ import (
 // version is set during the build process (i.e. the Makefile).
 // It follows Go's convention for module version, where the version
 // starts with the letter v, followed by a semantic version.
-var version = "v0.0.0-dev"
+var version = "v0.4.0"
 
 // Specification returns the Plugin's Specification.
 func Specification() sdk.Specification {


### PR DESCRIPTION
### Description

Changes the version to `(devel)`, to match the new build process

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-nats-jetstream/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
