### PR TITLE
Fixing connection name generation when empty

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -88,7 +88,6 @@ func Parse(cfg map[string]string) (Config, error) {
 	config := Config{
 		URLs:                    strings.Split(cfg[KeyURLs], ","),
 		Subject:                 cfg[KeySubject],
-		ConnectionName:          generateConnectionName(),
 		NKeyPath:                cfg[KeyNKeyPath],
 		CredentialsFilePath:     cfg[KeyCredentialsFilePath],
 		TLSClientCertPath:       cfg[KeyTLSClientCertPath],
@@ -98,8 +97,10 @@ func Parse(cfg map[string]string) (Config, error) {
 		ReconnectWait:           DefaultReconnectWait,
 	}
 
-	if connectionName, ok := cfg[KeyConnectionName]; ok {
+	if connectionName, ok := cfg[KeyConnectionName]; ok && connectionName != "" {
 		config.ConnectionName = connectionName
+	} else {
+		config.ConnectionName = generateConnectionName()
 	}
 
 	if err := config.parseMaxReconnects(cfg[KeyMaxReconnects]); err != nil {
@@ -155,5 +156,5 @@ func (c *Config) parseReconnectWait(reconnectWaitStr string) error {
 // generateConnectionName generates a random connection name.
 // The connection name will be made up of the default connection name and a random UUID.
 func generateConnectionName() string {
-	return DefaultConnectionNamePrefix + uuid.New().String()
+	return DefaultConnectionNamePrefix + uuid.NewString()
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -18,6 +18,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/google/uuid"
 )
 
 func TestParse(t *testing.T) {
@@ -179,6 +181,24 @@ func TestParse(t *testing.T) {
 				URLs:           []string{"nats://127.0.0.1:1222"},
 				Subject:        "foo",
 				ConnectionName: "my_super_connection",
+				MaxReconnects:  DefaultMaxReconnects,
+				ReconnectWait:  DefaultReconnectWait,
+			},
+			wantErr: false,
+		},
+		{
+			name: "success, empty connection name",
+			args: args{
+				cfg: map[string]string{
+					KeyURLs:           "nats://127.0.0.1:1222",
+					KeySubject:        "foo",
+					KeyConnectionName: "",
+				},
+			},
+			want: Config{
+				URLs:           []string{"nats://127.0.0.1:1222"},
+				Subject:        "foo",
+				ConnectionName: DefaultConnectionNamePrefix + uuid.NewString(),
 				MaxReconnects:  DefaultMaxReconnects,
 				ReconnectWait:  DefaultReconnectWait,
 			},

--- a/destination/destination.go
+++ b/destination/destination.go
@@ -52,7 +52,7 @@ func (d *Destination) Parameters() map[string]sdk.Parameter {
 			Description: "A name of a subject to which the connector should write.",
 		},
 		config.KeyConnectionName: {
-			Default:     "conduit-connection-<uuid>",
+			Default:     "",
 			Required:    false,
 			Description: "Optional connection name which will come in handy when it comes to monitoring.",
 		},

--- a/source/source.go
+++ b/source/source.go
@@ -53,7 +53,7 @@ func (s *Source) Parameters() map[string]sdk.Parameter {
 			Description: "A name of a subject from which the connector should read.",
 		},
 		config.KeyConnectionName: {
-			Default:     "conduit-connection-<uuid>",
+			Default:     "",
 			Required:    false,
 			Description: "Optional connection name which will come in handy when it comes to monitoring.",
 		},


### PR DESCRIPTION
### Description

Because the connector sets a default value `conduit-connection-<uuid>` (for source and destination), the connection generation name is never triggered, and all connection names are set to `conduit-connection-<uuid>`, which causes issues every time you have more than one connection active.

The fix does remove the default value and properly generates the connection name in case of the user not setting the same.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-nats-jetstream/pulls) for the same update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
