### PR TITLE
improved nats error handling and status

### DIFF
--- a/common/callbacks.go
+++ b/common/callbacks.go
@@ -1,0 +1,47 @@
+package common
+
+import (
+	"context"
+
+	sdk "github.com/conduitio/conduit-connector-sdk"
+	"github.com/nats-io/nats.go"
+)
+
+func ErrorHandlerCallback(ctx context.Context) nats.ErrHandler {
+	return func(c *nats.Conn, sub *nats.Subscription, err error) {
+		sdk.Logger(ctx).
+			Error().
+			Err(err).
+			Str("connection_name", c.Opts.Name).
+			Str("subscription", sub.Subject).
+			Msg("nats error")
+	}
+}
+
+func DisconnectErrCallback(ctx context.Context) nats.ConnErrHandler {
+	return func(c *nats.Conn, err error) {
+		sdk.Logger(ctx).
+			Warn().
+			Err(err).
+			Str("connection_name", c.Opts.Name).
+			Msg("disconnected from NATS server")
+	}
+}
+
+func ReconnectCallback(ctx context.Context) nats.ConnHandler {
+	return func(c *nats.Conn) {
+		sdk.Logger(ctx).
+			Warn().
+			Str("connection_name", c.Opts.Name).
+			Msg("reconnected to NATS server")
+	}
+}
+
+func ClosedCallback(ctx context.Context) nats.ConnHandler {
+	return func(c *nats.Conn) {
+		sdk.Logger(ctx).
+			Warn().
+			Str("connection_name", c.Opts.Name).
+			Msg("connection has been closed")
+	}
+}

--- a/common/callbacks.go
+++ b/common/callbacks.go
@@ -1,3 +1,17 @@
+// Copyright © 2022 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package common
 
 import (
@@ -13,6 +27,9 @@ func ErrorHandlerCallback(ctx context.Context) nats.ErrHandler {
 			Error().
 			Err(err).
 			Str("connection_name", c.Opts.Name).
+			Str("cluster_name", c.ConnectedClusterName()).
+			Str("server_id", c.ConnectedServerId()).
+			Str("server_name", c.ConnectedServerName()).
 			Str("subscription", sub.Subject).
 			Msg("nats error")
 	}
@@ -24,6 +41,9 @@ func DisconnectErrCallback(ctx context.Context) nats.ConnErrHandler {
 			Warn().
 			Err(err).
 			Str("connection_name", c.Opts.Name).
+			Str("cluster_name", c.ConnectedClusterName()).
+			Str("server_id", c.ConnectedServerId()).
+			Str("server_name", c.ConnectedServerName()).
 			Msg("disconnected from NATS server")
 	}
 }
@@ -33,6 +53,9 @@ func ReconnectCallback(ctx context.Context) nats.ConnHandler {
 		sdk.Logger(ctx).
 			Warn().
 			Str("connection_name", c.Opts.Name).
+			Str("cluster_name", c.ConnectedClusterName()).
+			Str("server_id", c.ConnectedServerId()).
+			Str("server_name", c.ConnectedServerName()).
 			Msg("reconnected to NATS server")
 	}
 }
@@ -42,6 +65,22 @@ func ClosedCallback(ctx context.Context) nats.ConnHandler {
 		sdk.Logger(ctx).
 			Warn().
 			Str("connection_name", c.Opts.Name).
+			Str("cluster_name", c.ConnectedClusterName()).
+			Str("server_id", c.ConnectedServerId()).
+			Str("server_name", c.ConnectedServerName()).
 			Msg("connection has been closed")
+	}
+}
+
+func DiscoveredServersCallback(ctx context.Context) nats.ConnHandler {
+	return func(c *nats.Conn) {
+		sdk.Logger(ctx).
+			Warn().
+			Str("connection_name", c.Opts.Name).
+			Str("cluster_name", c.ConnectedClusterName()).
+			Str("server_id", c.ConnectedServerId()).
+			Str("server_name", c.ConnectedServerName()).
+			Strs("servers", c.Servers()).
+			Msg("servers have been discovered")
 	}
 }

--- a/destination/destination.go
+++ b/destination/destination.go
@@ -143,17 +143,10 @@ func (d *Destination) Open(ctx context.Context) error {
 			Msg("nats error")
 	})
 
-	conn.SetDisconnectErrHandler(func(c *nats.Conn, err error) {
-		sdk.Logger(ctx).Warn().Err(err).Str("connection_name", c.Opts.Name).Msg("disconnected from NATS server")
-	})
-
-	conn.SetReconnectHandler(func(c *nats.Conn) {
-		sdk.Logger(ctx).Warn().Str("connection_name", c.Opts.Name).Msg("reconnected to NATS server")
-	})
-
-	conn.SetClosedHandler(func(c *nats.Conn) {
-		sdk.Logger(ctx).Warn().Str("connection_name", c.Opts.Name).Msg("connection has been closed")
-	})
+	conn.SetErrorHandler(common.ErrorHandlerCallback(ctx))
+	conn.SetDisconnectErrHandler(common.DisconnectErrCallback(ctx))
+	conn.SetReconnectHandler(common.ReconnectCallback(ctx))
+	conn.SetClosedHandler(common.ClosedCallback(ctx))
 
 	d.writer, err = jetstream.NewWriter(jetstream.WriterParams{
 		Conn:          conn,

--- a/destination/destination.go
+++ b/destination/destination.go
@@ -147,6 +147,7 @@ func (d *Destination) Open(ctx context.Context) error {
 	conn.SetDisconnectErrHandler(common.DisconnectErrCallback(ctx))
 	conn.SetReconnectHandler(common.ReconnectCallback(ctx))
 	conn.SetClosedHandler(common.ClosedCallback(ctx))
+	conn.SetDiscoveredServersHandler(common.DiscoveredServersCallback(ctx))
 
 	d.writer, err = jetstream.NewWriter(jetstream.WriterParams{
 		Conn:          conn,

--- a/source/source.go
+++ b/source/source.go
@@ -31,7 +31,6 @@ type Source struct {
 
 	config   Config
 	iterator *jetstream.Iterator
-	errC     chan error
 }
 
 // NewSource creates new instance of the Source.
@@ -133,13 +132,12 @@ func (s *Source) Configure(_ context.Context, cfg map[string]string) error {
 	}
 
 	s.config = config
-	s.errC = make(chan error, 1)
 
 	return nil
 }
 
 // Open opens a connection to NATS and initializes iterators.
-func (s *Source) Open(_ context.Context, position sdk.Position) error {
+func (s *Source) Open(ctx context.Context, position sdk.Position) error {
 	opts, err := common.GetConnectionOptions(s.config.Config)
 	if err != nil {
 		return fmt.Errorf("get connection options: %w", err)
@@ -150,10 +148,26 @@ func (s *Source) Open(_ context.Context, position sdk.Position) error {
 		return fmt.Errorf("connect to NATS: %w", err)
 	}
 
-	// register an error handler for async errors,
-	// the Source listens to them within the Read method and propagates the error if it occurs.
-	conn.SetErrorHandler(func(con *nats.Conn, sub *nats.Subscription, err error) {
-		s.errC <- err
+	// Async handlers & callbacks
+	conn.SetErrorHandler(func(c *nats.Conn, sub *nats.Subscription, err error) {
+		sdk.Logger(ctx).
+			Error().
+			Err(err).
+			Str("connection_name", c.Opts.Name).
+			Str("subscription", sub.Subject).
+			Msg("nats error")
+	})
+
+	conn.SetDisconnectErrHandler(func(c *nats.Conn, err error) {
+		sdk.Logger(ctx).Warn().Err(err).Str("connection_name", c.Opts.Name).Msg("disconnected from NATS server")
+	})
+
+	conn.SetReconnectHandler(func(c *nats.Conn) {
+		sdk.Logger(ctx).Warn().Str("connection_name", c.Opts.Name).Msg("reconnected to NATS server")
+	})
+
+	conn.SetClosedHandler(func(c *nats.Conn) {
+		sdk.Logger(ctx).Warn().Str("connection_name", c.Opts.Name).Msg("connection has been closed")
 	})
 
 	s.iterator, err = jetstream.NewIterator(jetstream.IteratorParams{
@@ -176,22 +190,16 @@ func (s *Source) Open(_ context.Context, position sdk.Position) error {
 // Read fetches a record from an iterator.
 // If there's no record will return sdk.ErrBackoffRetry.
 func (s *Source) Read(ctx context.Context) (sdk.Record, error) {
-	select {
-	case err := <-s.errC:
-		return sdk.Record{}, fmt.Errorf("got an async error: %w", err)
-
-	default:
-		if !s.iterator.HasNext() {
-			return sdk.Record{}, sdk.ErrBackoffRetry
-		}
-
-		record, err := s.iterator.Next(ctx)
-		if err != nil {
-			return sdk.Record{}, fmt.Errorf("read next record: %w", err)
-		}
-
-		return record, nil
+	if !s.iterator.HasNext() {
+		return sdk.Record{}, sdk.ErrBackoffRetry
 	}
+
+	record, err := s.iterator.Next(ctx)
+	if err != nil {
+		return sdk.Record{}, fmt.Errorf("read next record: %w", err)
+	}
+
+	return record, nil
 }
 
 // Ack acknowledges a message at the given position.

--- a/source/source.go
+++ b/source/source.go
@@ -153,6 +153,7 @@ func (s *Source) Open(ctx context.Context, position sdk.Position) error {
 	conn.SetDisconnectErrHandler(common.DisconnectErrCallback(ctx))
 	conn.SetReconnectHandler(common.ReconnectCallback(ctx))
 	conn.SetClosedHandler(common.ClosedCallback(ctx))
+	conn.SetDiscoveredServersHandler(common.DiscoveredServersCallback(ctx))
 
 	s.iterator, err = jetstream.NewIterator(jetstream.IteratorParams{
 		Conn:           conn,

--- a/source/source.go
+++ b/source/source.go
@@ -149,26 +149,10 @@ func (s *Source) Open(ctx context.Context, position sdk.Position) error {
 	}
 
 	// Async handlers & callbacks
-	conn.SetErrorHandler(func(c *nats.Conn, sub *nats.Subscription, err error) {
-		sdk.Logger(ctx).
-			Error().
-			Err(err).
-			Str("connection_name", c.Opts.Name).
-			Str("subscription", sub.Subject).
-			Msg("nats error")
-	})
-
-	conn.SetDisconnectErrHandler(func(c *nats.Conn, err error) {
-		sdk.Logger(ctx).Warn().Err(err).Str("connection_name", c.Opts.Name).Msg("disconnected from NATS server")
-	})
-
-	conn.SetReconnectHandler(func(c *nats.Conn) {
-		sdk.Logger(ctx).Warn().Str("connection_name", c.Opts.Name).Msg("reconnected to NATS server")
-	})
-
-	conn.SetClosedHandler(func(c *nats.Conn) {
-		sdk.Logger(ctx).Warn().Str("connection_name", c.Opts.Name).Msg("connection has been closed")
-	})
+	conn.SetErrorHandler(common.ErrorHandlerCallback(ctx))
+	conn.SetDisconnectErrHandler(common.DisconnectErrCallback(ctx))
+	conn.SetReconnectHandler(common.ReconnectCallback(ctx))
+	conn.SetClosedHandler(common.ClosedCallback(ctx))
 
 	s.iterator, err = jetstream.NewIterator(jetstream.IteratorParams{
 		Conn:           conn,


### PR DESCRIPTION
### Description

1. The async error channel wasn't useful because NATS can manage that internally by its own callbacks.
2. Adding callback handlers for server disconnection (when allowing reconnection), reconnection and the connection closed (it will not reconnect anymore)

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-nats-jetstream/pulls) for the same update/change.
- [ ] I have written unit tests. _(they are just callbacks for the NATS client that generates logs)_
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
