### PR TITLE
Remove unused error handler

### DIFF
--- a/destination/destination.go
+++ b/destination/destination.go
@@ -134,15 +134,6 @@ func (d *Destination) Open(ctx context.Context) error {
 	}
 
 	// Async handlers & callbacks
-	conn.SetErrorHandler(func(c *nats.Conn, sub *nats.Subscription, err error) {
-		sdk.Logger(ctx).
-			Error().
-			Err(err).
-			Str("connection_name", c.Opts.Name).
-			Str("subscription", sub.Subject).
-			Msg("nats error")
-	})
-
 	conn.SetErrorHandler(common.ErrorHandlerCallback(ctx))
 	conn.SetDisconnectErrHandler(common.DisconnectErrCallback(ctx))
 	conn.SetReconnectHandler(common.ReconnectCallback(ctx))


### PR DESCRIPTION
### Description

A small followup to https://github.com/conduitio-labs/conduit-connector-nats-jetstream/pull/61 which removes an unused error handler. It is overwritten by the error handler declared in the next line.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-nats-jetstream/pulls) for the same update/change.
- [ ] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.